### PR TITLE
feat: 로그인과 회원가입 관련 API 개발

### DIFF
--- a/poppingcore/boot/external-api/build.gradle
+++ b/poppingcore/boot/external-api/build.gradle
@@ -14,8 +14,11 @@ jar { enabled = false }
 
 dependencies {
     implementation project(':data')
+    implementation project(':cloud')
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/controller/AuthMemberController.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/controller/AuthMemberController.java
@@ -1,0 +1,57 @@
+package com.popping.domain.auth.controller;
+
+import com.popping.domain.auth.dto.AuthMemberDto;
+import com.popping.domain.auth.service.SignInService;
+import com.popping.domain.auth.service.SignUpService;
+import com.popping.global.responseform.ResponseForm;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthMemberController {
+    private final SignUpService signUpService;
+    private final SignInService signInService;
+
+    private static final String AUTHORIZATION = "Authorization";
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<ResponseForm<AuthMemberDto.SignUpResponse>> signUp(@RequestPart @Valid AuthMemberDto.SignUpRequest signUpRequestDto,
+                                                                             @RequestPart(required = false) MultipartFile img) {
+        return ResponseEntity.created(URI.create(""))
+                .body(ResponseForm.<AuthMemberDto.SignUpResponse>builder()
+                        .httpStatus(HttpStatus.CREATED)
+                        .responseMessage("Sign up successfully")
+                        .content(signUpService.signUp(signUpRequestDto, img))
+                        .build());
+    }
+
+    @PostMapping("/sign-in")
+    public ResponseEntity<ResponseForm<AuthMemberDto.SignInResponse>> signIn(@RequestBody @Valid AuthMemberDto.SignInRequest signInRequestDto) {
+        return ResponseEntity.ok(
+                ResponseForm.<AuthMemberDto.SignInResponse>builder()
+                        .httpStatus(HttpStatus.OK)
+                        .responseMessage("Response successfully")
+                        .content(signInService.signIn(signInRequestDto))
+                        .build()
+        );
+    }
+
+    @GetMapping("/sign-in/re/status")
+    public ResponseEntity<ResponseForm<AuthMemberDto.SignInRequiredResponse>> verifySignInRequired(HttpServletRequest request) {
+        return ResponseEntity.ok(
+                ResponseForm.<AuthMemberDto.SignInRequiredResponse>builder()
+                        .httpStatus(HttpStatus.OK)
+                        .responseMessage("Retrieve successfully")
+                        .content(signInService.verifySignInRequired(request.getHeader(AUTHORIZATION)))
+                        .build()
+        );
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/controller/SmsController.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/controller/SmsController.java
@@ -1,0 +1,34 @@
+package com.popping.domain.auth.controller;
+
+import com.popping.domain.auth.dto.AuthSmsDto;
+import com.popping.domain.auth.service.SmsVerifyService;
+import com.popping.global.responseform.ResponseForm;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sms")
+public class SmsController {
+    private final SmsVerifyService smsVerifyUseCase;
+
+    @PostMapping("/send")
+    public ResponseEntity<Void> sendSms() {
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<ResponseForm<AuthSmsDto.VerifyCodeResponse>> verifySmsCode(@RequestBody @Valid AuthSmsDto.VerifyCodeRequest request) {
+        return ResponseEntity.ok(ResponseForm.<AuthSmsDto.VerifyCodeResponse>builder()
+                        .httpStatus(HttpStatus.OK)
+                        .responseMessage("Verify Successfully")
+                        .content(smsVerifyUseCase.verifyCode(request))
+                .build());
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/controller/TokenController.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/controller/TokenController.java
@@ -1,0 +1,30 @@
+package com.popping.domain.auth.controller;
+
+import com.popping.domain.auth.dto.TokenDto;
+import com.popping.domain.auth.service.TokenService;
+import com.popping.global.responseform.ResponseForm;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+    private final TokenService tokenService;
+
+    private static final String AUTHORIZATION = "Authorization";
+
+    @GetMapping("/tokens")
+    public ResponseEntity<ResponseForm<?>> reIssueTokens(HttpServletRequest request) {
+        return ResponseEntity.ok(
+                ResponseForm.<TokenDto.TokenResponse>builder()
+                        .httpStatus(HttpStatus.OK)
+                        .responseMessage("Retrieve successfully")
+                        .content(tokenService.reIssueTokens(request.getHeader(AUTHORIZATION)))
+                        .build()
+        );
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/dto/AuthMemberDto.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/dto/AuthMemberDto.java
@@ -1,0 +1,136 @@
+package com.popping.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.popping.data.member.data.member.entity.Member;
+import com.popping.data.member.data.member.entity.PolicyTerm;
+import com.popping.data.member.data.member.entity.ostype.OsType;
+import com.popping.data.member.data.member.entity.signupplatform.SignUpPlatform;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+public class AuthMemberDto {
+    @Getter
+    @Setter
+    public static class SignUpRequest {
+        @NotBlank
+        private final String name;
+        @NotBlank @Email
+        private final String email;
+        @NotBlank
+        private final String phoneNumber;
+        @NotBlank
+        private final String birthDate;
+        @NotBlank
+        private final String firebaseToken;
+        private final String extension;
+        @JsonProperty(value = "isAllowNotify")
+        private final boolean isAllowNotify;
+        @JsonProperty(value = "isAllowTermOne")
+        private final boolean isAllowTermOne;
+        @JsonProperty(value = "isAllowTermTwo")
+        private final boolean isAllowTermTwo;
+        @JsonProperty(value = "isAllowTermThree")
+        private final boolean isAllowTermThree;
+        private final SignUpPlatform signUpPlatform;
+        private final OsType osType;
+
+        @Builder
+        public SignUpRequest(String name, String birthDate, String email, String firebaseToken, String extension, boolean isAllowNotify, boolean isAllowTermOne, boolean isAllowTermThree, boolean isAllowTermTwo, String phoneNumber, SignUpPlatform signUpPlatform, OsType osType) {
+            this.name = name;
+            this.birthDate = birthDate;
+            this.email = email;
+            this.firebaseToken = firebaseToken;
+            this.extension = extension;
+            this.isAllowNotify = isAllowNotify;
+            this.isAllowTermOne = isAllowTermOne;
+            this.isAllowTermThree = isAllowTermThree;
+            this.isAllowTermTwo = isAllowTermTwo;
+            this.phoneNumber = phoneNumber;
+            this.signUpPlatform = signUpPlatform;
+            this.osType = osType;
+        }
+
+        public Member of(MultipartFile img) {
+            return Member.builder()
+                    .name(name)
+                    .email(email)
+                    .phoneNumber(phoneNumber)
+                    .birthDate(birthDate)
+                    .isAllowNotify(isAllowNotify)
+                    .signUpPlatform(signUpPlatform)
+                    .firebaseToken(firebaseToken)
+                    .profileImgName(img == null || img.isEmpty() ? null : UUID.randomUUID().toString())
+                    .osType(osType)
+                    .build();
+        }
+
+        public PolicyTerm of(Member member) {
+            return PolicyTerm.builder()
+                    .member(member)
+                    .isAllowTermOne(isAllowTermOne)
+                    .isAllowTermTwo(isAllowTermTwo)
+                    .isAllowTermThree(isAllowTermThree)
+                    .build();
+        }
+    }
+
+    @Getter
+    public static class SignUpResponse {
+        private TokenDto.Tokens tokens;
+
+        @Builder
+        public SignUpResponse(TokenDto.Tokens token) {
+            this.tokens = token;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SignInRequest {
+        @NotBlank @Email
+        private String email;
+        private SignUpPlatform signUpPlatform;
+
+        @Builder
+        public SignInRequest(String email, SignUpPlatform signUpPlatform) {
+            this.email = email;
+            this.signUpPlatform = signUpPlatform;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class SignInResponse {
+        private TokenDto.Tokens tokens;
+        @JsonProperty(value = "isRegistered")
+        private boolean isRegistered;
+
+        @Builder
+        public SignInResponse(boolean isRegistered, TokenDto.Tokens tokens) {
+            this.isRegistered = isRegistered;
+            this.tokens = tokens;
+        }
+    }
+
+
+    @Getter
+    @Setter
+    public static class SignInRequiredResponse {
+        private TokenDto.Token accessToken;
+        @JsonProperty(value = "isSignInRequired")
+        private boolean isSignInRequired;
+
+        @Builder
+        public SignInRequiredResponse(TokenDto.Token accessToken, boolean isSignInRequired) {
+            this.isSignInRequired = isSignInRequired;
+            this.accessToken = accessToken;
+        }
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/dto/AuthSmsDto.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/dto/AuthSmsDto.java
@@ -1,0 +1,33 @@
+package com.popping.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+public class AuthSmsDto {
+    @Getter
+    public static class VerifyCodeRequest {
+        @NotBlank
+        private final String phoneNumber;
+        @NotBlank
+        private final String code;
+
+        @Builder
+        public VerifyCodeRequest(String phoneNumber, String code) {
+            this.phoneNumber = phoneNumber;
+            this.code = code;
+        }
+    }
+
+    @Getter
+    public static class VerifyCodeResponse {
+        private final String alreadySignUpPlatform;
+        private final boolean isValidCode;
+
+        @Builder
+        public VerifyCodeResponse(String alreadySignUpPlatform, boolean isValidCode) {
+            this.alreadySignUpPlatform = alreadySignUpPlatform;
+            this.isValidCode = isValidCode;
+        }
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/dto/TokenDto.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/dto/TokenDto.java
@@ -1,0 +1,42 @@
+package com.popping.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+public class TokenDto {
+    @Getter
+    public static class Token {
+        private final String token;
+        private final Date expiredTime;
+
+        @Builder
+        public Token(String token, Date expiredTime) {
+            this.expiredTime = expiredTime;
+            this.token = token;
+        }
+    }
+
+    @Getter
+    public static class Tokens {
+        private final Token refreshToken;
+        private final Token accessToken;
+
+        @Builder
+        public Tokens(Token accessToken, Token refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+    }
+
+    @Getter
+    public static class TokenResponse {
+        private Tokens tokens;
+
+        @Builder
+        public TokenResponse(Tokens tokens) {
+            this.tokens = tokens;
+        }
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/service/SignInService.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/service/SignInService.java
@@ -1,0 +1,48 @@
+package com.popping.domain.auth.service;
+
+import com.popping.data.member.data.member.entity.Member;
+import com.popping.data.member.data.member.service.MemberService;
+import com.popping.domain.auth.dto.AuthMemberDto;
+import com.popping.domain.auth.dto.TokenDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SignInService {
+    private final MemberService memberService;
+    private final TokenService tokenService;
+
+    @Transactional
+    public AuthMemberDto.SignInResponse signIn(AuthMemberDto.SignInRequest signInRequestDto) {
+        Optional<Member> requesterOp = memberService.findMember(signInRequestDto.getEmail(), signInRequestDto.getSignUpPlatform());
+
+        if (requesterOp.isEmpty()) {
+            return AuthMemberDto.SignInResponse.builder().isRegistered(false).tokens(TokenDto.Tokens.builder().build()).build();
+        }
+
+        Member requester = requesterOp.get();
+        TokenDto.Tokens tokens = tokenService.createTokens(requester.getPk(), requester.getRole());
+        requester.updateRefreshToken(tokens.getRefreshToken().getToken());
+        return AuthMemberDto.SignInResponse.builder().isRegistered(true).tokens(tokens).build();
+    }
+
+    public AuthMemberDto.SignInRequiredResponse verifySignInRequired(String authorizationHeaderValue) {
+        String refreshToken = tokenService.getToken(authorizationHeaderValue);
+
+        if (tokenService.isNotValidRefreshToken(refreshToken)) {
+            return AuthMemberDto.SignInRequiredResponse.builder().isSignInRequired(true).build();
+        }
+
+        Member requester = memberService.findMemberByToken(refreshToken);
+        TokenDto.Token accessToken = tokenService.createAccessToken(requester.getPk(), requester.getRole());
+
+        return AuthMemberDto.SignInRequiredResponse.builder()
+                .isSignInRequired(false)
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/service/SignUpService.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/service/SignUpService.java
@@ -1,0 +1,41 @@
+package com.popping.domain.auth.service;
+
+import com.popping.data.member.data.member.entity.Member;
+import com.popping.data.member.data.member.entity.signupplatform.SignUpPlatform;
+import com.popping.data.member.data.member.service.MemberService;
+import com.popping.data.member.data.member.service.PolicyTermService;
+import com.popping.domain.auth.dto.AuthMemberDto;
+import com.popping.domain.auth.dto.TokenDto;
+import com.popping.domain.img.service.ImgSaveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpService {
+    private final MemberService memberService;
+    private final ImgSaveService imgSaveService;
+    private final PolicyTermService policyTermService;
+    private final TokenService tokenService;
+
+    @Transactional
+    public AuthMemberDto.SignUpResponse signUp(AuthMemberDto.SignUpRequest signUpRequestDto, MultipartFile file) {
+        Member requester = signUpRequestDto.of(file);
+        memberService.saveMember(requester);
+        TokenDto.Tokens tokens = tokenService.createTokens(requester.getPk(), requester.getRole());
+        requester.updateRefreshToken(tokens.getRefreshToken().getToken());
+        policyTermService.savePolicyTerm(signUpRequestDto.of(requester));
+
+        if (isKakaoProfileImgSaveCond(signUpRequestDto.getSignUpPlatform(), file)) {
+            imgSaveService.saveProfileImg(requester.getProfileImgName(), signUpRequestDto.getExtension(), file);
+        }
+
+        return new AuthMemberDto.SignUpResponse(tokens);
+    }
+
+    protected boolean isKakaoProfileImgSaveCond(SignUpPlatform signUpPlatform, MultipartFile file) {
+        return signUpPlatform.equals(SignUpPlatform.KAKAO) && file != null && !file.isEmpty();
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/service/SmsVerifyService.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/service/SmsVerifyService.java
@@ -1,0 +1,40 @@
+package com.popping.domain.auth.service;
+
+import com.popping.data.member.data.member.entity.Member;
+import com.popping.data.member.data.member.service.MemberService;
+import com.popping.domain.auth.dto.AuthSmsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SmsVerifyService {
+    private final MemberService memberService;
+
+    //todo 모든 메서드 sms 결제시 구현
+    public void sendVerificationCode(String phoneNumber) {
+
+    }
+
+    public boolean isValidCode(String code) {
+        if (code.equals("111"))
+            return false;
+
+        return true;
+    }
+
+    public AuthSmsDto.VerifyCodeResponse verifyCode(AuthSmsDto.VerifyCodeRequest verifyCodeRequest) {
+        AuthSmsDto.VerifyCodeResponse.VerifyCodeResponseBuilder verifyBuilder = AuthSmsDto.VerifyCodeResponse.builder();
+
+        if (isValidCode(verifyCodeRequest.getCode())) {
+            verifyBuilder.isValidCode(true);
+        }
+
+        Optional<Member> requester = memberService.findMemberByPhoneNum(verifyCodeRequest.getPhoneNumber());
+        requester.ifPresent(member -> verifyBuilder.alreadySignUpPlatform(member.getSignUpPlatform().getName()));
+
+        return verifyBuilder.build();
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/service/TokenService.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/auth/service/TokenService.java
@@ -1,0 +1,84 @@
+package com.popping.domain.auth.service;
+
+import com.popping.data.member.data.member.entity.Member;
+import com.popping.data.member.data.member.entity.role.Role;
+import com.popping.data.member.data.member.service.MemberService;
+import com.popping.domain.auth.dto.TokenDto;
+import com.popping.global.config.jwt.TokenProvider;
+import com.popping.global.exception.SignInRequiredException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final TokenProvider tokenProvider;
+    private final MemberService memberService;
+
+    private static final String BEARER = "Bearer ";
+
+    public TokenDto.Tokens createTokens(Long memberPk, Role role) {
+        return TokenDto.Tokens.builder()
+                .refreshToken(createRefreshToken(memberPk, role))
+                .accessToken(createAccessToken(memberPk, role))
+                .build();
+    }
+
+    public TokenDto.Token createRefreshToken(Long memberPk, Role role) {
+        String refreshToken = tokenProvider.createRefreshToken(memberPk, role);
+        return TokenDto.Token.builder()
+                .token(refreshToken)
+                .expiredTime(getExpirationTime(refreshToken))
+                .build();
+    }
+
+    public TokenDto.Token createAccessToken(Long memberPk, Role role) {
+        String accessToken = tokenProvider.createAccessToken(memberPk, role);
+        return TokenDto.Token.builder()
+                .token(accessToken)
+                .expiredTime(getExpirationTime(accessToken))
+                .build();
+    }
+
+    public boolean isExpired(String token) {
+        return tokenProvider.isExpired(token);
+    }
+
+    public boolean isNotValidToken(String authorizationHeaderValue) {
+        return !tokenProvider.isValidToken(getToken(authorizationHeaderValue));
+    }
+
+    public Date getExpirationTime(String token) {
+        return tokenProvider.getExpirationTime(token);
+    }
+
+    @Transactional
+    public TokenDto.TokenResponse reIssueTokens(String authorizationHeaderValue) {
+        String refreshToken = getToken(authorizationHeaderValue);
+
+        if (isNotValidRefreshToken(refreshToken)) {
+            throw new SignInRequiredException();
+        }
+
+        Member requester = memberService.findMemberByToken(refreshToken);
+        TokenDto.Tokens tokens = createTokens(requester.getPk(), requester.getRole());
+        requester.updateRefreshToken(tokens.getRefreshToken().getToken());
+
+        return TokenDto.TokenResponse.builder().tokens(tokens).build();
+    }
+
+    public boolean isNotValidRefreshToken(String refreshToken) {
+        return isNotValidToken(refreshToken) || !tokenProvider.isRefreshToken(refreshToken);
+    }
+
+    public String getToken(String authorizationHeaderValue) {
+        return authorizationHeaderValue == null
+                ? null
+                : authorizationHeaderValue.replace(BEARER, "");
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/domain/img/service/ImgSaveService.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/domain/img/service/ImgSaveService.java
@@ -1,0 +1,35 @@
+package com.popping.domain.img.service;
+
+import com.popping.client.aws.s3.S3Service;
+import com.popping.global.exceptionmessage.ExceptionMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class ImgSaveService {
+    private final S3Service s3Service;
+
+    private static final String PROFILE_PATH = "profile/";
+    private static final String DEFAULT_EXTENSION = "jpeg";
+
+    public void saveProfileImg(String imgName, String extension, MultipartFile img) {
+        if (img.isEmpty()) {
+            throw new NoSuchElementException(ExceptionMessage.IMG_NOT_EXIST.getMessage());
+        }
+        if (!extension.equalsIgnoreCase(DEFAULT_EXTENSION)) {
+            throw new UnsupportedOperationException(ExceptionMessage.UNSUPPORTED_IMAGE_FORMAT.getMessage());
+        }
+
+        try {
+            String imgOriginalName = imgName + "." + extension;
+            s3Service.saveImg(PROFILE_PATH, imgOriginalName, img.getBytes());
+        } catch (IOException e) {
+            throw new IllegalStateException(e.getMessage());
+        }
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/global/advice/ValidExceptionHandler.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/global/advice/ValidExceptionHandler.java
@@ -1,0 +1,100 @@
+package com.popping.global.advice;
+
+import com.popping.global.exception.SignInRequiredException;
+import com.popping.global.responseform.ResponseStatus;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class ValidExceptionHandler {
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ResponseStatus> noSuchElementException(NoSuchElementException e) {
+        return ResponseEntity.badRequest()
+                .body(
+                        ResponseStatus.builder()
+                                .httpCode(HttpStatus.BAD_REQUEST.value())
+                                .httpStatus(HttpStatus.BAD_REQUEST)
+                                .responseMessage(e.getMessage())
+                                .build()
+                );
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ResponseStatus> entityNotFoundException(Exception e) {
+        return ResponseEntity.badRequest()
+                .body(
+                        ResponseStatus.builder()
+                                .httpCode(HttpStatus.BAD_REQUEST.value())
+                                .httpStatus(HttpStatus.BAD_REQUEST)
+                                .responseMessage(e.getMessage())
+                                .build()
+                );
+    }
+
+    @ExceptionHandler(UnsupportedOperationException.class)
+    public ResponseEntity<ResponseStatus> unsupportedOperationException(Exception e) {
+        return ResponseEntity.badRequest()
+                .body(
+                        ResponseStatus.builder()
+                                .httpCode(HttpStatus.BAD_REQUEST.value())
+                                .httpStatus(HttpStatus.BAD_REQUEST)
+                                .responseMessage(e.getMessage())
+                                .build()
+                );
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ResponseStatus> ConstraintViolationException1(Exception e) {
+        return ResponseEntity.badRequest()
+                .body(
+                        ResponseStatus.builder()
+                                .httpCode(HttpStatus.BAD_REQUEST.value())
+                                .httpStatus(HttpStatus.BAD_REQUEST)
+                                .responseMessage(e.getMessage())
+                                .build()
+                );
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseStatus> MethodArgumentNotValidException(Exception e) {
+        return ResponseEntity.badRequest()
+                .body(
+                        ResponseStatus.builder()
+                                .httpCode(HttpStatus.BAD_REQUEST.value())
+                                .httpStatus(HttpStatus.BAD_REQUEST)
+                                .responseMessage(e.getMessage())
+                                .build()
+                );
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ResponseStatus> IllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.badRequest()
+                .body(
+                        ResponseStatus.builder()
+                                .httpCode(HttpStatus.BAD_REQUEST.value())
+                                .httpStatus(HttpStatus.BAD_REQUEST)
+                                .responseMessage(e.getMessage())
+                                .build()
+                );
+    }
+
+    @ExceptionHandler(SignInRequiredException.class)
+    public ResponseEntity<ResponseStatus> SignInRequiredException(SignInRequiredException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(
+                        ResponseStatus.builder()
+                                .httpCode(HttpStatus.FORBIDDEN.value())
+                                .httpStatus(HttpStatus.FORBIDDEN)
+                                .responseMessage(e.getMessage())
+                                .build()
+                );
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/global/config/jwt/JwtAuthenticationFilter.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/global/config/jwt/JwtAuthenticationFilter.java
@@ -25,7 +25,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String authorization = request.getHeader(AUTHORIZATION);
         String token = getToken(authorization);
 
-        if (tokenProvider.validToken(token)) {
+        if (tokenProvider.isValidToken(token)) {
             Authentication authentication = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/poppingcore/boot/external-api/src/main/java/com/popping/global/config/security/SecurityConfig.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/global/config/security/SecurityConfig.java
@@ -27,6 +27,12 @@ public class SecurityConfig {
         httpSecurity
                 .authorizeHttpRequests(httpRequest -> httpRequest
                         .requestMatchers(HttpMethod.GET, "/health-check").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/sign-up").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/sign-in").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/sign-in/re/status").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/tokens").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/sms/send").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/sms/verify").permitAll()
                         .anyRequest().authenticated());
 
         httpSecurity

--- a/poppingcore/boot/external-api/src/main/java/com/popping/global/exception/SignInRequiredException.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/global/exception/SignInRequiredException.java
@@ -1,0 +1,7 @@
+package com.popping.global.exception;
+
+public class SignInRequiredException extends RuntimeException {
+    public SignInRequiredException() {
+        super("Please sign in again");
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/global/exceptionmessage/ExceptionMessage.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/global/exceptionmessage/ExceptionMessage.java
@@ -1,0 +1,15 @@
+package com.popping.global.exceptionmessage;
+
+import lombok.Getter;
+
+@Getter
+public enum ExceptionMessage {
+    UNSUPPORTED_IMAGE_FORMAT("지원하지 않는 확장자입니다."),
+    IMG_NOT_EXIST("파일이 존재하지 않습니다.");
+
+    private final String message;
+
+    ExceptionMessage(String message) {
+        this.message = message;
+    }
+}

--- a/poppingcore/boot/external-api/src/main/java/com/popping/global/responseform/ResponseForm.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/global/responseform/ResponseForm.java
@@ -1,0 +1,22 @@
+package com.popping.global.responseform;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ResponseForm <T> {
+    private final ResponseStatus responseStatus;
+    private final T content;
+
+    @Builder
+    public ResponseForm(T content, HttpStatus httpStatus, String responseMessage) {
+        this.content = content;
+        this.responseStatus = ResponseStatus.builder()
+                .httpStatus(httpStatus)
+                .httpCode(httpStatus.value())
+                .responseMessage(responseMessage)
+                .build();
+    }
+}
+

--- a/poppingcore/boot/external-api/src/main/java/com/popping/global/responseform/ResponseStatus.java
+++ b/poppingcore/boot/external-api/src/main/java/com/popping/global/responseform/ResponseStatus.java
@@ -1,0 +1,19 @@
+package com.popping.global.responseform;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ResponseStatus {
+    private final int httpCode;
+    private final HttpStatus httpStatus;
+    private final String responseMessage;
+
+    @Builder
+    public ResponseStatus(int httpCode, HttpStatus httpStatus, String responseMessage) {
+        this.httpCode = httpCode;
+        this.httpStatus = httpStatus;
+        this.responseMessage = responseMessage;
+    }
+}

--- a/poppingcore/boot/external-api/src/main/resources/application.yml
+++ b/poppingcore/boot/external-api/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  config:
+    import:
+      - classpath:/application-data.yml
+      - classpath:/application-cloud.yml
+
   jackson:
     time-zone: Asia/Seoul
 

--- a/poppingcore/build.gradle
+++ b/poppingcore/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 subprojects {
 	apply plugin: 'java'
+	apply plugin: 'java-library'
 	apply plugin: 'org.springframework.boot'
 	apply plugin: 'io.spring.dependency-management'
 

--- a/poppingcore/cloud/build.gradle
+++ b/poppingcore/cloud/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.popping'
+version = '0.0.1-SNAPSHOT'
+
+bootJar { enabled = false }
+jar { enabled = true }
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'software.amazon.awssdk:s3:2.28.14'
+    implementation 'org.springframework:spring-context'
+
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/poppingcore/cloud/src/main/java/com/popping/client/aws/s3/S3Service.java
+++ b/poppingcore/cloud/src/main/java/com/popping/client/aws/s3/S3Service.java
@@ -1,0 +1,25 @@
+package com.popping.client.aws.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final S3Client s3Client;
+
+    public void saveImg(String imgPath, String imgOriginalName, byte[] file) {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(imgPath + imgOriginalName)
+                .build();
+        s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file));
+    }
+}

--- a/poppingcore/cloud/src/main/java/com/popping/config/aws/s3/S3Config.java
+++ b/poppingcore/cloud/src/main/java/com/popping/config/aws/s3/S3Config.java
@@ -1,0 +1,36 @@
+package com.popping.config.aws.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.s3.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.s3.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner presigner() {
+        return S3Presigner.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey,secretKey)))
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/poppingcore/cloud/src/main/resources/application-cloud.yml
+++ b/poppingcore/cloud/src/main/resources/application-cloud.yml
@@ -1,0 +1,10 @@
+cloud:
+  aws:
+    region: ap-northeast-2
+    stack:
+      auto: false
+    s3:
+      bucket: popping-s3
+      credentials:
+        accessKey: ${accessKey}
+        secretKey: ${secretKey}

--- a/poppingcore/data/build.gradle
+++ b/poppingcore/data/build.gradle
@@ -16,6 +16,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // tsid
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.0'
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/Member.java
+++ b/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/Member.java
@@ -1,0 +1,71 @@
+package com.popping.data.member.data.member.entity;
+
+import com.popping.data.member.data.member.entity.ostype.OsType;
+import com.popping.data.member.data.member.entity.role.Role;
+import com.popping.data.member.data.member.entity.signupplatform.SignUpPlatform;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+    @Id @Tsid
+    private Long pk;
+
+    @NotNull
+    @Column(name = "NAME")
+    private String name;
+    @NotNull
+    @Column(name = "EMAIL", unique = true)
+    private String email;
+    @NotNull
+    @Column(name = "PHONE_NUMBER", unique = true)
+    private String phoneNumber;
+    @NotNull
+    @Column(name = "BIRTH_DATE")
+    private String birthDate;
+    @Column(name = "PRFOFILE_IMG_NAME")
+    private String profileImgName;
+    @Column(name = "FIREBASE_TOKEN", columnDefinition = "VARBINARY(400) NOT NULL")
+    private String firebaseToken;
+    @Column(name = "REFRESH_TOKEN", columnDefinition = "VARBINARY(400)")
+    private String refreshToken;
+    @Column(name = "IS_ALLOW_NOTIFY")
+    private boolean isAllowNotify;
+
+    @Enumerated(value = EnumType.STRING)
+    private SignUpPlatform signUpPlatform;
+    @Enumerated(value = EnumType.STRING)
+    private Role role;
+    @Enumerated(value = EnumType.STRING)
+    private OsType osType;
+
+    @Builder
+    public Member(String birthDate, String email, String firebaseToken, boolean isAllowNotify, String name, String phoneNumber, String profileImgName, String refreshToken, SignUpPlatform signUpPlatform, OsType osType) {
+        this.birthDate = birthDate;
+        this.email = email;
+        this.firebaseToken = firebaseToken;
+        this.isAllowNotify = isAllowNotify;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.profileImgName = profileImgName;
+        this.refreshToken = refreshToken;
+        this.role = Role.USER;
+        this.signUpPlatform = signUpPlatform;
+        this.osType = osType;
+    }
+
+    public void updateProfileImg(String profileImgName) {
+        this.profileImgName = profileImgName;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/PolicyTerm.java
+++ b/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/PolicyTerm.java
@@ -1,0 +1,39 @@
+package com.popping.data.member.data.member.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PolicyTerm {
+    @Id
+    private Long pk;
+
+    @NotNull
+    @MapsId
+    @OneToOne(targetEntity = Member.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Member member;
+
+    @Column(name = "IS_ALLOW_TERM_ONE")
+    private boolean isAllowTermOne;
+
+    @Column(name = "IS_ALLOW_TERM_TWO")
+    private boolean isAllowTermTwo;
+
+    @Column(name = "IS_ALLOW_TERM_THREE")
+    private boolean isAllowTermThree;
+
+    @Builder
+    public PolicyTerm(Member member, boolean isAllowTermOne, boolean isAllowTermTwo, boolean isAllowTermThree) {
+        this.member = member;
+        this.isAllowTermOne = isAllowTermOne;
+        this.isAllowTermTwo = isAllowTermTwo;
+        this.isAllowTermThree = isAllowTermThree;
+    }
+}

--- a/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/ostype/OsType.java
+++ b/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/ostype/OsType.java
@@ -1,0 +1,5 @@
+package com.popping.data.member.data.member.entity.ostype;
+
+public enum OsType {
+    ANDROID, IOS
+}

--- a/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/role/Role.java
+++ b/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/role/Role.java
@@ -1,4 +1,4 @@
-package com.popping.data.member.role;
+package com.popping.data.member.data.member.entity.role;
 
 import lombok.Getter;
 

--- a/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/signupplatform/SignUpPlatform.java
+++ b/poppingcore/data/src/main/java/com/popping/data/member/data/member/entity/signupplatform/SignUpPlatform.java
@@ -1,0 +1,17 @@
+package com.popping.data.member.data.member.entity.signupplatform;
+
+import lombok.Getter;
+
+@Getter
+public enum SignUpPlatform {
+    KAKAO("카카오"),
+    NAVER("네이버"),
+    GOOGLE("구글"),
+    APPLE("애플");
+
+    private final String name;
+
+    SignUpPlatform(String name) {
+        this.name = name;
+    }
+}

--- a/poppingcore/data/src/main/java/com/popping/data/member/data/member/repository/MemberRepository.java
+++ b/poppingcore/data/src/main/java/com/popping/data/member/data/member/repository/MemberRepository.java
@@ -1,0 +1,18 @@
+package com.popping.data.member.data.member.repository;
+
+import com.popping.data.member.data.member.entity.Member;
+import com.popping.data.member.data.member.entity.signupplatform.SignUpPlatform;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    @Query("select m from Member m where m.email = :email and m.signUpPlatform = :signUpPlatform")
+    Optional<Member> findMember(@Param("email") String email, @Param("signUpPlatform") SignUpPlatform signUpPlatform);
+    @Query("select m from Member m where m.refreshToken = :refreshToken")
+    Optional<Member> findByRefreshToken(@Param("refreshToken") String refreshToken);
+    @Query("select m from Member m where m.phoneNumber = :phoneNumber")
+    Optional<Member> findByPhoneNumber(@Param("phoneNumber") String phoneNum);
+}

--- a/poppingcore/data/src/main/java/com/popping/data/member/data/member/repository/PolicyTermRepository.java
+++ b/poppingcore/data/src/main/java/com/popping/data/member/data/member/repository/PolicyTermRepository.java
@@ -1,0 +1,7 @@
+package com.popping.data.member.data.member.repository;
+
+import com.popping.data.member.data.member.entity.PolicyTerm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PolicyTermRepository extends JpaRepository<PolicyTerm, Long> {
+}

--- a/poppingcore/data/src/main/java/com/popping/data/member/data/member/service/MemberService.java
+++ b/poppingcore/data/src/main/java/com/popping/data/member/data/member/service/MemberService.java
@@ -1,0 +1,34 @@
+package com.popping.data.member.data.member.service;
+
+import com.popping.data.member.data.member.entity.Member;
+import com.popping.data.member.data.member.entity.signupplatform.SignUpPlatform;
+import com.popping.data.member.data.member.repository.MemberRepository;
+import com.popping.global.exceptionmessage.ExceptionMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public Member saveMember(Member member) {
+        return memberRepository.save(member);
+    }
+
+    public Optional<Member> findMember(String email, SignUpPlatform signUpPlatform) {
+        return memberRepository.findMember(email, signUpPlatform);
+    }
+
+    public Member findMemberByToken(String refreshToken) {
+        return memberRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new NoSuchElementException(ExceptionMessage.MEMBER_NOT_FOUND.getMessage()));
+    }
+
+    public Optional<Member> findMemberByPhoneNum(String phoneNum) {
+        return memberRepository.findByPhoneNumber(phoneNum);
+    }
+}

--- a/poppingcore/data/src/main/java/com/popping/data/member/data/member/service/PolicyTermService.java
+++ b/poppingcore/data/src/main/java/com/popping/data/member/data/member/service/PolicyTermService.java
@@ -1,0 +1,16 @@
+package com.popping.data.member.data.member.service;
+
+import com.popping.data.member.data.member.entity.PolicyTerm;
+import com.popping.data.member.data.member.repository.PolicyTermRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PolicyTermService {
+    private final PolicyTermRepository policyTermRepository;
+
+    public void savePolicyTerm(PolicyTerm policyTerm) {
+        policyTermRepository.save(policyTerm);
+    }
+}

--- a/poppingcore/data/src/main/java/com/popping/global/exceptionmessage/ExceptionMessage.java
+++ b/poppingcore/data/src/main/java/com/popping/global/exceptionmessage/ExceptionMessage.java
@@ -1,0 +1,14 @@
+package com.popping.global.exceptionmessage;
+
+import lombok.Getter;
+
+@Getter
+public enum ExceptionMessage {
+    MEMBER_NOT_FOUND("해당 사용자를 찾을 수 없습니다.");
+
+    private final String message;
+
+    ExceptionMessage(String message) {
+        this.message = message;
+    }
+}

--- a/poppingcore/data/src/main/resources/application-data.yml
+++ b/poppingcore/data/src/main/resources/application-data.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
     open-in-view: false

--- a/poppingcore/settings.gradle
+++ b/poppingcore/settings.gradle
@@ -4,4 +4,5 @@ findProject(':boot:batch')?.name = 'batch'
 include 'boot:external-api'
 findProject(':boot:external-api')?.name = 'external-api'
 include 'data'
+include 'cloud'
 


### PR DESCRIPTION
* 로그인, 회원가입, 토큰 유효성 확인, 토큰 재발급 API 개발
* SMS 관련 API는 임시로 개발
* Jwt의 subject로 token 종류 구분
* 이미지 s3에 직접 저장 로직 개발
* 다른 모듈 yml 파일 못읽는 버그 수정